### PR TITLE
Add character preference copier page

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,7 +54,10 @@ PREFERENCE_ITEMS = {
         "type": "file"
     },
     "disabledTips": {"label": "DisabledTipsMap.xml", "path": "DisabledTipsMap.xml", "type": "file"},
-    "binFiles": {"label": "*.bin files", "path": "*.bin", "type": "glob"}
+    "iconPositionsBin": {"label": "IconPositions.bin", "path": "IconPositions.bin", "type": "file"},
+    "ignoreListBin": {"label": "IgnoreList.bin", "path": "IgnoreList.bin", "type": "file"},
+    "referencesBin": {"label": "References.bin", "path": "References.bin", "type": "file"},
+    "textMacroBin": {"label": "TextMacro.bin", "path": "TextMacro.bin", "type": "file"}
 }
 
 

--- a/app.py
+++ b/app.py
@@ -6,6 +6,10 @@ import subprocess
 import os
 import logging
 import platform
+import shutil
+from datetime import datetime
+from glob import glob
+
 from flask import Flask, render_template, request, jsonify
 from flask_cors import CORS # Required for cross-origin requests if you run frontend from different origin
 
@@ -23,10 +27,152 @@ app = Flask(__name__)
 # Enable CORS for development. In a production scenario, you might want to restrict this.
 CORS(app)
 
+PREFERENCE_ITEMS = {
+    "charCfg": {"label": "Char.cfg", "path": "Char.cfg", "type": "file"},
+    "prefsXml": {"label": "Prefs.xml", "path": "Prefs.xml", "type": "file"},
+    "chatFolder": {"label": "Chat folder", "path": "Chat", "type": "folder"},
+    "containersBank": {"label": "Containers/Bank.xml", "path": os.path.join("Containers", "Bank.xml"), "type": "file"},
+    "containersInventory": {"label": "Containers/Inventory.xml", "path": os.path.join("Containers", "Inventory.xml"), "type": "file"},
+    "containersShortcutBars": {
+        "label": "Containers/ShortcutBar*.xml",
+        "path": os.path.join("Containers", "ShortcutBar*.xml"),
+        "type": "glob"
+    },
+    "dockAreasLayouts": {
+        "label": "DockAreas/DockArea*.xml",
+        "path": os.path.join("DockAreas", "DockArea*.xml"),
+        "type": "glob"
+    },
+    "dockAreasMap": {
+        "label": "DockAreas/PlanetMapViewConfig.xml",
+        "path": os.path.join("DockAreas", "PlanetMapViewConfig.xml"),
+        "type": "file"
+    },
+    "dockAreasRollup": {
+        "label": "DockAreas/RollupArea.xml",
+        "path": os.path.join("DockAreas", "RollupArea.xml"),
+        "type": "file"
+    },
+    "disabledTips": {"label": "DisabledTipsMap.xml", "path": "DisabledTipsMap.xml", "type": "file"},
+    "binFiles": {"label": "*.bin files", "path": "*.bin", "type": "glob"}
+}
+
+
+def _ensure_char_folder_name(character_id: str) -> str:
+    """Return the directory name for a character ID (ensure it is prefixed with 'Char')."""
+    char_str = str(character_id)
+    if char_str.lower().startswith("char"):
+        return char_str
+    return f"Char{char_str}"
+
+
+def _get_character_prefs_path(base_path: str, account_name: str, character_id: str) -> str:
+    """Build the absolute path to a character's preference directory."""
+    if not base_path or not account_name or character_id is None:
+        return ""
+    folder_name = _ensure_char_folder_name(character_id)
+    return os.path.join(base_path, account_name, folder_name)
+
+
+def _backup_preference_item(target_dir: str, backup_root: str, item_def: dict) -> bool:
+    """Create a backup copy of the requested item if it exists in the target directory."""
+    if not backup_root:
+        return False
+
+    os.makedirs(backup_root, exist_ok=True)
+
+    if item_def["type"] == "file":
+        source_path = os.path.join(target_dir, item_def["path"])
+        if os.path.isfile(source_path):
+            backup_path = os.path.join(backup_root, item_def["path"])
+            os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+            shutil.copy2(source_path, backup_path)
+            return True
+        return False
+
+    if item_def["type"] == "folder":
+        source_dir = os.path.join(target_dir, item_def["path"])
+        if os.path.isdir(source_dir):
+            backup_dir = os.path.join(backup_root, item_def["path"])
+            if os.path.isdir(backup_dir):
+                shutil.rmtree(backup_dir)
+            shutil.copytree(source_dir, backup_dir)
+            return True
+        return False
+
+    if item_def["type"] == "glob":
+        pattern = os.path.join(target_dir, item_def["path"])
+        matches = [match for match in glob(pattern, recursive=True) if os.path.isfile(match)]
+        copied_any = False
+        for match in matches:
+            relative = os.path.relpath(match, target_dir)
+            backup_path = os.path.join(backup_root, relative)
+            os.makedirs(os.path.dirname(backup_path), exist_ok=True)
+            shutil.copy2(match, backup_path)
+            copied_any = True
+        return copied_any
+
+    return False
+
+
+def _copy_preference_item(source_dir: str, target_dir: str, item_def: dict):
+    """Copy a single preference item from source to target. Returns (copied_paths, missing_paths)."""
+    copied_paths = []
+    missing_paths = []
+
+    if item_def["type"] == "file":
+        source_path = os.path.join(source_dir, item_def["path"])
+        if os.path.isfile(source_path):
+            dest_path = os.path.join(target_dir, item_def["path"])
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            shutil.copy2(source_path, dest_path)
+            copied_paths.append(item_def["path"])
+        else:
+            missing_paths.append(item_def["path"])
+        return copied_paths, missing_paths
+
+    if item_def["type"] == "folder":
+        source_path = os.path.join(source_dir, item_def["path"])
+        if os.path.isdir(source_path):
+            dest_path = os.path.join(target_dir, item_def["path"])
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            if os.path.isdir(dest_path):
+                shutil.rmtree(dest_path)
+            shutil.copytree(source_path, dest_path)
+            copied_paths.append(item_def["path"])
+        else:
+            missing_paths.append(item_def["path"])
+        return copied_paths, missing_paths
+
+    if item_def["type"] == "glob":
+        pattern = os.path.join(source_dir, item_def["path"])
+        matches = [match for match in glob(pattern, recursive=True) if os.path.isfile(match)]
+        if not matches:
+            missing_paths.append(item_def["path"])
+            return copied_paths, missing_paths
+
+        for match in matches:
+            relative = os.path.relpath(match, source_dir)
+            dest_path = os.path.join(target_dir, relative)
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            shutil.copy2(match, dest_path)
+            copied_paths.append(relative)
+
+        return copied_paths, missing_paths
+
+    missing_paths.append(item_def.get("path", "unknown"))
+    return copied_paths, missing_paths
+
 @app.route('/')
 def index():
     """Serves the main HTML page."""
     return render_template('index.html')
+
+
+@app.route('/preferences')
+def preferences():
+    """Serves the character preferences management page."""
+    return render_template('preferences.html')
 
 @app.route('/check_and_focus_window', methods=['POST'])
 def check_and_focus_window():
@@ -397,6 +543,196 @@ def close_running_instances():
             "status": "error",
             "message": f"Error closing game instances: {str(e)}"
         }), 500
+
+
+@app.route('/copy_preferences', methods=['POST'])
+def copy_preferences():
+    """Copy selected preference files from a source character to one or more targets."""
+    if platform.system() != 'Windows':
+        logger.warning("Preference copying requested on unsupported platform")
+        return jsonify({
+            "status": "unsupported",
+            "message": "Character preference copying is only supported on Windows"
+        }), 200
+
+    data = request.json or {}
+
+    base_path = (data.get('prefsBasePath') or '').strip()
+    source_info = data.get('source') or {}
+    targets_info = data.get('targets') or []
+    requested_items = data.get('items') or []
+    create_backup = bool(data.get('createBackup'))
+
+    if not base_path:
+        return jsonify({
+            "status": "error",
+            "message": "Preference base path is required"
+        }), 400
+
+    if not os.path.isdir(base_path):
+        return jsonify({
+            "status": "error",
+            "message": f"Preference base path does not exist: {base_path}"
+        }), 400
+
+    source_account = (source_info.get('accountName') or '').strip()
+    source_character_id = source_info.get('characterId')
+
+    if not source_account or source_character_id is None or source_character_id == '':
+        return jsonify({
+            "status": "error",
+            "message": "Source account and character must be specified"
+        }), 400
+
+    if not isinstance(targets_info, list) or len(targets_info) == 0:
+        return jsonify({
+            "status": "error",
+            "message": "At least one target character must be selected"
+        }), 400
+
+    selected_items = []
+    invalid_items = []
+    for item_id in requested_items:
+        item_def = PREFERENCE_ITEMS.get(item_id)
+        if item_def:
+            selected_items.append({**item_def, "id": item_id})
+        else:
+            invalid_items.append(item_id)
+
+    if not selected_items:
+        return jsonify({
+            "status": "error",
+            "message": "No valid preference items were requested for copying"
+        }), 400
+
+    source_dir = _get_character_prefs_path(base_path, source_account, source_character_id)
+    if not source_dir or not os.path.isdir(source_dir):
+        return jsonify({
+            "status": "error",
+            "message": f"Source character preferences not found at {source_dir or 'unknown path'}"
+        }), 400
+
+    logger.info(
+        "Copying preferences from %s/%s to %d target(s) with items %s",
+        source_account,
+        source_character_id,
+        len(targets_info),
+        [item['id'] for item in selected_items]
+    )
+
+    timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    results = []
+    errors = []
+
+    source_identifier = (source_account.lower(), str(source_character_id))
+
+    for target in targets_info:
+        target_account = (target.get('accountName') or '').strip()
+        target_character_id = target.get('characterId')
+
+        if not target_account or target_character_id is None or target_character_id == '':
+            error_msg = "Target account and character must be provided"
+            errors.append(error_msg)
+            logger.error(error_msg)
+            continue
+
+        target_identifier = (target_account.lower(), str(target_character_id))
+        if target_identifier == source_identifier:
+            logger.info("Skipping target identical to source: %s/%s", target_account, target_character_id)
+            continue
+
+        target_dir = _get_character_prefs_path(base_path, target_account, target_character_id)
+        if not target_dir:
+            error_msg = f"Unable to determine target directory for {target_account}/{target_character_id}"
+            errors.append(error_msg)
+            logger.error(error_msg)
+            continue
+
+        os.makedirs(target_dir, exist_ok=True)
+
+        backup_dir = None
+        backed_up_items = []
+        if create_backup:
+            backup_dir = os.path.join(target_dir, f"backup_{timestamp}")
+            for item in selected_items:
+                try:
+                    if _backup_preference_item(target_dir, backup_dir, item):
+                        backed_up_items.append(item["label"])
+                except Exception as backup_error:
+                    logger.error(
+                        "Failed to back up %s for %s/%s: %s",
+                        item["label"],
+                        target_account,
+                        target_character_id,
+                        backup_error,
+                        exc_info=True
+                    )
+                    errors.append(
+                        f"Backup failed for {target_account}/{target_character_id} item {item['label']}: {backup_error}"
+                    )
+
+        copied_details = []
+        missing_details = []
+
+        for item in selected_items:
+            try:
+                copied_paths, missing_paths = _copy_preference_item(source_dir, target_dir, item)
+                if copied_paths:
+                    copied_details.append({
+                        "itemId": item["id"],
+                        "label": item["label"],
+                        "paths": copied_paths
+                    })
+                if missing_paths:
+                    missing_details.append({
+                        "itemId": item["id"],
+                        "label": item["label"],
+                        "paths": missing_paths
+                    })
+            except Exception as copy_error:
+                logger.error(
+                    "Failed to copy %s from %s/%s to %s/%s: %s",
+                    item["label"],
+                    source_account,
+                    source_character_id,
+                    target_account,
+                    target_character_id,
+                    copy_error,
+                    exc_info=True
+                )
+                errors.append(
+                    f"Copy failed for {target_account}/{target_character_id} item {item['label']}: {copy_error}"
+                )
+
+        results.append({
+            "accountName": target_account,
+            "characterId": str(target_character_id),
+            "copied": copied_details,
+            "missing": missing_details,
+            "backupDirectory": backup_dir if backed_up_items else None,
+            "backedUpItems": backed_up_items
+        })
+
+    if not results and errors:
+        return jsonify({
+            "status": "error",
+            "message": "Preference copy failed for all targets",
+            "errors": errors,
+            "invalidItems": invalid_items
+        }), 500
+
+    status = "success" if not errors else "partial_success"
+    message = f"Copied preferences to {len(results)} character(s)."
+    if errors:
+        message += " Some items encountered issues."
+
+    return jsonify({
+        "status": status,
+        "message": message,
+        "results": results,
+        "errors": errors,
+        "invalidItems": invalid_items
+    }), 200
 
 if __name__ == '__main__':
     # Run the Flask app on all interfaces so it's reachable externally.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -598,7 +598,7 @@ button {
     background-color: #0a1118;
     border: 1px solid #1a3d3d;
     border-radius: 0.5rem;
-    padding: 0.75rem;
+    padding: 0.5rem 0.75rem;  /* Reduced vertical padding */
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -634,7 +634,7 @@ button {
 .preference-character-row {
     border: 1px solid #1a3333;
     border-radius: 0.35rem;
-    padding: 0.5rem;
+    padding: 0.35rem 0.5rem;  /* Reduced vertical padding */
     transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -592,3 +592,57 @@ button {
 .account-card .flex.space-x-2 > button:first-child {
     margin-left: 0;
 }
+
+/* Preference copier specific styling */
+.preference-item {
+    background-color: #0a1118;
+    border: 1px solid #1a3d3d;
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.preference-item:hover {
+    border-color: #4dd0d0;
+    box-shadow: 0 0 10px rgba(77, 208, 208, 0.15);
+}
+
+.preference-badge {
+    font-size: 0.65rem;
+    letter-spacing: 0.08em;
+    padding: 0.1rem 0.35rem;
+    border-radius: 9999px;
+    text-transform: uppercase;
+}
+
+.preference-badge-recommended {
+    background-color: rgba(77, 208, 208, 0.15);
+    border: 1px solid rgba(77, 208, 208, 0.35);
+    color: #4dd0d0;
+}
+
+.preference-badge-optional {
+    background-color: rgba(208, 160, 77, 0.15);
+    border: 1px solid rgba(208, 160, 77, 0.35);
+    color: #d0a04d;
+}
+
+.preference-account-card {
+    min-height: 100%;
+}
+
+.preference-character-row {
+    border: 1px solid #1a3333;
+    border-radius: 0.35rem;
+    padding: 0.5rem;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.preference-character-row:hover {
+    border-color: #2a4d4d;
+    background-color: #0f1f1f;
+}
+
+.preference-character-disabled {
+    opacity: 0.4;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -646,3 +646,42 @@ button {
 .preference-character-disabled {
     opacity: 0.4;
 }
+
+/* Dark theme dropdown styling - fixes the white background issue */
+select {
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20width%3D%22292.4%22%20height%3D%22292.4%22%3E%3Cpath%20fill%3D%22%234dd0d0%22%20d%3D%22M287%2069.4a17.6%2017.6%200%200%200-13-5.4H18.4c-5%200-9.3%201.8-12.9%205.4A17.6%2017.6%200%200%200%200%2082.2c0%205%201.8%209.3%205.4%2012.9l128%20127.9c3.6%203.6%207.8%205.4%2012.8%205.4s9.2-1.8%2012.8-5.4L287%2095c3.5-3.5%205.4-7.8%205.4-12.8%200-5-1.9-9.2-5.5-12.8z%22%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 0.7em top 50%;
+    background-size: 0.65em auto;
+    padding-right: 2rem;
+}
+
+/* Fix for option background color in dropdowns */
+select option {
+    background-color: #0d1a1a;
+    color: #4dd0d0;
+}
+
+/* Style for the source character dropdown specifically */
+#sourceCharacter {
+    background-color: #0d1a1a;
+    color: #4dd0d0;
+    border: 2px solid #1a4d4d;
+    border-radius: 0.5rem;
+    transition: all 0.2s ease-in-out;
+}
+
+#sourceCharacter:focus {
+    outline: none;
+    border-color: #4dd0d0;
+    box-shadow: 0 0 0 2px rgba(77, 208, 208, 0.2);
+}
+
+#sourceCharacter option {
+    background-color: #0d1a1a;
+    color: #4dd0d0;
+    padding: 0.75rem;
+}

--- a/static/js/preferences.js
+++ b/static/js/preferences.js
@@ -1,0 +1,567 @@
+// static/js/preferences.js
+// Handles the character preference copy UI and communication with the backend.
+
+const PREFERENCE_ITEMS = [
+    {
+        id: 'charCfg',
+        label: 'Char.cfg',
+        description: 'Core character configuration file. Copy to preserve metadata and character-specific settings.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'prefsXml',
+        label: 'Prefs.xml',
+        description: 'Primary UI layout and preference file. Copy to keep window layouts, sorting, and toggles.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'chatFolder',
+        label: 'Chat/',
+        description: 'Entire chat configuration folder, including window layouts, channels, and color schemes.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'containersBank',
+        label: 'Containers/Bank.xml',
+        description: 'Bank window layout. Copy to restore how backpacks are arranged inside the bank.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'containersInventory',
+        label: 'Containers/Inventory.xml',
+        description: 'Inventory window organization and layout.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'containersShortcutBars',
+        label: 'Containers/ShortcutBar*.xml',
+        description: 'Shortcut bar positions and contents. Copy with caution when professions differ.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'dockAreasLayouts',
+        label: 'DockAreas/DockArea*.xml',
+        description: 'Docked window definitions. Copy to keep toolbars and docked UI modules in place.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'dockAreasMap',
+        label: 'DockAreas/PlanetMapViewConfig.xml',
+        description: 'Planet map configuration including window placement and zoom state.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'dockAreasRollup',
+        label: 'DockAreas/RollupArea.xml',
+        description: 'Roll-up window states—what is expanded or collapsed.',
+        defaultChecked: true,
+        category: 'recommended'
+    },
+    {
+        id: 'disabledTips',
+        label: 'DisabledTipsMap.xml',
+        description: 'Tracks which tutorial tips were dismissed. Optional quality-of-life preference.',
+        defaultChecked: false,
+        category: 'optional'
+    },
+    {
+        id: 'binFiles',
+        label: '*.bin files',
+        description: 'Binary preference data such as icon positions, ignore lists, macros, and references.',
+        defaultChecked: false,
+        category: 'optional'
+    }
+];
+
+const PREF_SOURCE_STORAGE_KEY = 'aoLauncherPrefSourceCharacter';
+
+const prefsBasePathInput = document.getElementById('prefsBasePath');
+const savePrefsBasePathBtn = document.getElementById('savePrefsBasePathBtn');
+const sourceCharacterSelect = document.getElementById('sourceCharacter');
+const preferenceItemsContainer = document.getElementById('preferenceItems');
+const targetAccountsContainer = document.getElementById('targetAccountsContainer');
+const selectAllTargetsBtn = document.getElementById('selectAllTargets');
+const clearAllTargetsBtn = document.getElementById('clearAllTargets');
+const copyBtn = document.getElementById('copyBtn');
+const copyWithBackupBtn = document.getElementById('copyWithBackupBtn');
+const prefsMessageBox = document.getElementById('prefsMessageBox');
+
+let messageTimeoutHandle = null;
+
+const defaultSettings = {
+    gameFolder: '',
+    dllFolder: '',
+    autoCycle: false,
+    prefsBasePath: '',
+    accounts: []
+};
+
+let appSettings = loadSettingsFromLocalStorage();
+let characterLookup = new Map();
+let sourceCharacterKey = localStorage.getItem(PREF_SOURCE_STORAGE_KEY) || '';
+let selectedTargets = new Set();
+
+function loadSettingsFromLocalStorage() {
+    const storedSettings = localStorage.getItem('aoLauncherSettings');
+    if (!storedSettings) {
+        return { ...defaultSettings };
+    }
+
+    try {
+        const parsed = JSON.parse(storedSettings);
+        const merged = { ...defaultSettings, ...parsed };
+        if (!Array.isArray(merged.accounts)) {
+            merged.accounts = [];
+        }
+        merged.accounts = merged.accounts.map(account => ({
+            ...account,
+            name: account?.name || account?.accountName || '',
+            characters: Array.isArray(account?.characters) ? account.characters : []
+        }));
+        merged.prefsBasePath = merged.prefsBasePath || '';
+        return merged;
+    } catch (error) {
+        console.error('Failed to parse aoLauncherSettings from storage', error);
+        return { ...defaultSettings };
+    }
+}
+
+function saveSettingsToLocalStorage() {
+    localStorage.setItem('aoLauncherSettings', JSON.stringify(appSettings));
+}
+
+function showPrefsMessage(message, type = 'info') {
+    if (!prefsMessageBox) return;
+
+    if (messageTimeoutHandle) {
+        clearTimeout(messageTimeoutHandle);
+    }
+
+    const baseClass = 'mt-2 p-3 rounded-lg text-center';
+    const typeClass = type === 'success'
+        ? 'message-success'
+        : type === 'error'
+            ? 'message-error'
+            : type === 'warning'
+                ? 'message-warning'
+                : 'message-info';
+
+    prefsMessageBox.textContent = message;
+    prefsMessageBox.className = `${baseClass} ${typeClass}`;
+    prefsMessageBox.classList.remove('hidden');
+
+    messageTimeoutHandle = setTimeout(() => {
+        prefsMessageBox.classList.add('hidden');
+    }, 6000);
+}
+
+function getCharacterKey(accountName, characterId) {
+    return `${accountName}::${characterId}`;
+}
+
+function rebuildCharacterLookup() {
+    characterLookup = new Map();
+
+    appSettings.accounts
+        .filter(acc => acc && acc.name)
+        .forEach(acc => {
+            acc.characters
+                .filter(char => char && char.id !== undefined && char.id !== null)
+                .forEach(char => {
+                    const key = getCharacterKey(acc.name, char.id);
+                    characterLookup.set(key, {
+                        accountName: acc.name,
+                        characterId: char.id,
+                        characterName: char.name || `Char ${char.id}`
+                    });
+                });
+        });
+
+    const validKeys = new Set(characterLookup.keys());
+    if (sourceCharacterKey && !validKeys.has(sourceCharacterKey)) {
+        sourceCharacterKey = '';
+        localStorage.removeItem(PREF_SOURCE_STORAGE_KEY);
+    }
+
+    selectedTargets = new Set(Array.from(selectedTargets).filter(key => validKeys.has(key) && key !== sourceCharacterKey));
+}
+
+function renderPreferenceItems() {
+    preferenceItemsContainer.innerHTML = '';
+
+    PREFERENCE_ITEMS.forEach(item => {
+        const itemWrapper = document.createElement('label');
+        itemWrapper.className = 'preference-item flex items-start gap-2 cursor-pointer';
+        itemWrapper.title = item.description;
+
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.value = item.id;
+        checkbox.checked = item.defaultChecked;
+        checkbox.className = 'mt-1 accent-[#4dd0d0]';
+
+        const textContainer = document.createElement('div');
+        textContainer.className = 'flex flex-col text-sm text-blue-100';
+
+        const labelLine = document.createElement('div');
+        labelLine.className = 'flex items-center gap-2';
+
+        const labelSpan = document.createElement('span');
+        labelSpan.className = 'text-cyan-100 font-semibold';
+        labelSpan.textContent = item.label;
+
+        const badge = document.createElement('span');
+        badge.className = `preference-badge ${item.category === 'optional' ? 'preference-badge-optional' : 'preference-badge-recommended'}`;
+        badge.textContent = item.category === 'optional' ? 'Optional' : 'Recommended';
+
+        labelLine.appendChild(labelSpan);
+        labelLine.appendChild(badge);
+
+        const description = document.createElement('span');
+        description.className = 'text-xs opacity-80';
+        description.textContent = item.description;
+
+        textContainer.appendChild(labelLine);
+        textContainer.appendChild(description);
+
+        itemWrapper.appendChild(checkbox);
+        itemWrapper.appendChild(textContainer);
+
+        preferenceItemsContainer.appendChild(itemWrapper);
+    });
+}
+
+function renderSourceDropdown() {
+    const previousValue = sourceCharacterKey;
+    sourceCharacterSelect.innerHTML = '';
+
+    const placeholderOption = document.createElement('option');
+    placeholderOption.value = '';
+    placeholderOption.textContent = 'Select a character';
+    sourceCharacterSelect.appendChild(placeholderOption);
+
+    const characters = Array.from(characterLookup.values())
+        .sort((a, b) => {
+            const accountCompare = a.accountName.localeCompare(b.accountName);
+            if (accountCompare !== 0) return accountCompare;
+            return (a.characterName || '').localeCompare(b.characterName || '');
+        });
+
+    characters.forEach(char => {
+        const option = document.createElement('option');
+        const key = getCharacterKey(char.accountName, char.characterId);
+        option.value = key;
+        option.textContent = `${char.characterName} (${char.accountName})`;
+        if (key === previousValue) {
+            option.selected = true;
+            sourceCharacterKey = key;
+        }
+        sourceCharacterSelect.appendChild(option);
+    });
+}
+
+function renderTargetAccounts() {
+    targetAccountsContainer.innerHTML = '';
+
+    if (!appSettings.accounts.length) {
+        targetAccountsContainer.innerHTML = '<p class="text-center text-gray-400 col-span-full">Add accounts on the launcher page to manage preferences.</p>';
+        return;
+    }
+
+    const accounts = [...appSettings.accounts].sort((a, b) => a.name.localeCompare(b.name));
+
+    accounts.forEach(account => {
+        const accountCard = document.createElement('div');
+        accountCard.className = 'account-card preference-account-card';
+
+        const header = document.createElement('div');
+        header.className = 'flex justify-between items-center mb-1';
+
+        const title = document.createElement('h3');
+        title.className = 'text-m font-semibold text-blue-200';
+        title.textContent = account.name;
+
+        const controls = document.createElement('div');
+        controls.className = 'flex gap-2 text-xs';
+
+        const allBtn = document.createElement('button');
+        allBtn.textContent = 'All';
+        allBtn.className = 'px-2 py-1 rounded-md uppercase';
+        allBtn.addEventListener('click', () => {
+            setAccountSelection(account.name, true);
+        });
+
+        const noneBtn = document.createElement('button');
+        noneBtn.textContent = 'None';
+        noneBtn.className = 'px-2 py-1 rounded-md uppercase';
+        noneBtn.addEventListener('click', () => {
+            setAccountSelection(account.name, false);
+        });
+
+        controls.appendChild(allBtn);
+        controls.appendChild(noneBtn);
+
+        header.appendChild(title);
+        header.appendChild(controls);
+
+        const charactersContainer = document.createElement('div');
+        charactersContainer.className = 'space-y-1';
+
+        const characters = [...account.characters].sort((a, b) => {
+            const nameA = (a.name || '').toLowerCase();
+            const nameB = (b.name || '').toLowerCase();
+            if (nameA === nameB) return String(a.id).localeCompare(String(b.id));
+            return nameA.localeCompare(nameB);
+        });
+
+        if (!characters.length) {
+            const empty = document.createElement('p');
+            empty.className = 'text-gray-400 text-xs';
+            empty.textContent = 'No characters configured.';
+            charactersContainer.appendChild(empty);
+        }
+
+        characters.forEach(char => {
+            const charKey = getCharacterKey(account.name, char.id);
+            const isSource = charKey === sourceCharacterKey;
+            const characterRow = document.createElement('div');
+            characterRow.className = 'character-item preference-character-row flex items-center gap-2';
+            if (isSource) {
+                characterRow.classList.add('preference-character-disabled');
+            }
+
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.className = 'character-checkbox accent-[#4dd0d0]';
+            checkbox.dataset.key = charKey;
+            checkbox.disabled = isSource;
+            checkbox.checked = selectedTargets.has(charKey);
+            checkbox.addEventListener('change', event => {
+                const key = event.target.dataset.key;
+                if (event.target.checked) {
+                    selectedTargets.add(key);
+                } else {
+                    selectedTargets.delete(key);
+                }
+            });
+
+            const text = document.createElement('div');
+            text.className = 'flex flex-col text-sm text-gray-100';
+
+            const nameLine = document.createElement('span');
+            nameLine.textContent = char.name || `Character ${char.id}`;
+
+            const metaLine = document.createElement('span');
+            metaLine.className = 'text-xs opacity-70';
+            metaLine.textContent = `ID: ${char.id}` + (isSource ? ' • Source character' : '');
+
+            text.appendChild(nameLine);
+            text.appendChild(metaLine);
+
+            characterRow.appendChild(checkbox);
+            characterRow.appendChild(text);
+
+            charactersContainer.appendChild(characterRow);
+        });
+
+        accountCard.appendChild(header);
+        accountCard.appendChild(charactersContainer);
+        targetAccountsContainer.appendChild(accountCard);
+    });
+}
+
+function setAccountSelection(accountName, shouldSelect) {
+    const account = appSettings.accounts.find(acc => acc.name === accountName);
+    if (!account) return;
+
+    account.characters.forEach(char => {
+        const key = getCharacterKey(accountName, char.id);
+        if (key === sourceCharacterKey) return;
+        if (shouldSelect) {
+            selectedTargets.add(key);
+        } else {
+            selectedTargets.delete(key);
+        }
+    });
+
+    renderTargetAccounts();
+}
+
+function handleSelectAllTargets() {
+    characterLookup.forEach((value, key) => {
+        if (key !== sourceCharacterKey) {
+            selectedTargets.add(key);
+        }
+    });
+    renderTargetAccounts();
+}
+
+function handleClearAllTargets() {
+    selectedTargets.clear();
+    renderTargetAccounts();
+}
+
+function getSelectedPreferenceItems() {
+    const checked = preferenceItemsContainer.querySelectorAll('input[type="checkbox"]:checked');
+    return Array.from(checked).map(input => input.value);
+}
+
+function buildTargetPayload() {
+    const targets = [];
+    selectedTargets.forEach(key => {
+        const entry = characterLookup.get(key);
+        if (entry) {
+            targets.push({
+                accountName: entry.accountName,
+                characterId: entry.characterId
+            });
+        }
+    });
+    return targets;
+}
+
+function getSourcePayload() {
+    if (!sourceCharacterKey) return null;
+    const entry = characterLookup.get(sourceCharacterKey);
+    if (!entry) return null;
+    return {
+        accountName: entry.accountName,
+        characterId: entry.characterId
+    };
+}
+
+async function handleCopyPreferences(createBackup) {
+    const basePath = prefsBasePathInput.value.trim();
+    if (!basePath) {
+        showPrefsMessage('Please set the path to your Prefs directory first.', 'error');
+        return;
+    }
+
+    if (appSettings.prefsBasePath !== basePath) {
+        appSettings.prefsBasePath = basePath;
+        saveSettingsToLocalStorage();
+    }
+
+    const source = getSourcePayload();
+    if (!source) {
+        showPrefsMessage('Select the character you want to copy preferences from.', 'error');
+        return;
+    }
+
+    const items = getSelectedPreferenceItems();
+    if (!items.length) {
+        showPrefsMessage('Select at least one preference file or folder to copy.', 'warning');
+        return;
+    }
+
+    const targets = buildTargetPayload();
+    if (!targets.length) {
+        showPrefsMessage('Choose at least one target character to receive the preferences.', 'warning');
+        return;
+    }
+
+    const payload = {
+        prefsBasePath: basePath,
+        source,
+        targets,
+        items,
+        createBackup
+    };
+
+    copyBtn.disabled = true;
+    copyWithBackupBtn.disabled = true;
+    showPrefsMessage('Copying preferences…', 'info');
+
+    try {
+        const response = await fetch('/copy_preferences', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify(payload)
+        });
+
+        const result = await response.json();
+        console.log('Preference copy result', result);
+
+        if (!response.ok || result.status === 'error') {
+            const message = result.message || 'Copy failed.';
+            showPrefsMessage(message, 'error');
+            return;
+        }
+
+        if (result.status === 'unsupported') {
+            showPrefsMessage(result.message || 'Preference copying is only supported on Windows.', 'warning');
+            return;
+        }
+
+        const message = result.message || (createBackup ? 'Preferences copied with backups.' : 'Preferences copied.');
+        const type = result.status === 'partial_success' ? 'warning' : 'success';
+        const detailedMessage = result.errors && result.errors.length
+            ? `${message} ${result.errors[0]}`
+            : message;
+        showPrefsMessage(detailedMessage, type);
+    } catch (error) {
+        console.error('Error copying preferences', error);
+        showPrefsMessage('An unexpected error occurred while copying preferences.', 'error');
+    } finally {
+        copyBtn.disabled = false;
+        copyWithBackupBtn.disabled = false;
+    }
+}
+
+function initialiseEventHandlers() {
+    savePrefsBasePathBtn.addEventListener('click', () => {
+        const path = prefsBasePathInput.value.trim();
+        appSettings.prefsBasePath = path;
+        saveSettingsToLocalStorage();
+        if (path) {
+            showPrefsMessage('Preference base path saved.', 'success');
+        } else {
+            showPrefsMessage('Preference base path cleared.', 'info');
+        }
+    });
+
+    prefsBasePathInput.addEventListener('keydown', event => {
+        if (event.key === 'Enter') {
+            event.preventDefault();
+            savePrefsBasePathBtn.click();
+        }
+    });
+
+    sourceCharacterSelect.addEventListener('change', event => {
+        sourceCharacterKey = event.target.value || '';
+        if (sourceCharacterKey) {
+            localStorage.setItem(PREF_SOURCE_STORAGE_KEY, sourceCharacterKey);
+            selectedTargets.delete(sourceCharacterKey);
+        } else {
+            localStorage.removeItem(PREF_SOURCE_STORAGE_KEY);
+        }
+        renderTargetAccounts();
+    });
+
+    selectAllTargetsBtn.addEventListener('click', handleSelectAllTargets);
+    clearAllTargetsBtn.addEventListener('click', handleClearAllTargets);
+
+    copyBtn.addEventListener('click', () => handleCopyPreferences(false));
+    copyWithBackupBtn.addEventListener('click', () => handleCopyPreferences(true));
+}
+
+function initialise() {
+    prefsBasePathInput.value = appSettings.prefsBasePath || '';
+    rebuildCharacterLookup();
+    renderPreferenceItems();
+    renderSourceDropdown();
+    renderTargetAccounts();
+    initialiseEventHandlers();
+}
+
+initialise();

--- a/static/js/preferences.js
+++ b/static/js/preferences.js
@@ -106,6 +106,9 @@ const preferenceItemsContainer = document.getElementById('preferenceItems');
 const targetAccountsContainer = document.getElementById('targetAccountsContainer');
 const selectAllTargetsBtn = document.getElementById('selectAllTargets');
 const clearAllTargetsBtn = document.getElementById('clearAllTargets');
+const selectAllPrefsBtn = document.getElementById('selectAllPrefs');
+const clearAllPrefsBtn = document.getElementById('clearAllPrefs');
+const defaultPrefsBtn = document.getElementById('defaultPrefs');
 const copyBtn = document.getElementById('copyBtn');
 const copyWithBackupBtn = document.getElementById('copyWithBackupBtn');
 const prefsMessageBox = document.getElementById('prefsMessageBox');
@@ -215,41 +218,31 @@ function renderPreferenceItems() {
 
     PREFERENCE_ITEMS.forEach(item => {
         const itemWrapper = document.createElement('label');
-        itemWrapper.className = 'preference-item flex items-start gap-2 cursor-pointer';
-        itemWrapper.title = item.description;
+        itemWrapper.className = 'preference-item flex items-center gap-2 cursor-pointer';
+        itemWrapper.title = item.description; // Keep description as tooltip
 
         const checkbox = document.createElement('input');
         checkbox.type = 'checkbox';
         checkbox.value = item.id;
         checkbox.checked = item.defaultChecked;
-        checkbox.className = 'mt-1 accent-[#4dd0d0]';
+        checkbox.className = 'accent-[#4dd0d0]';
 
         const textContainer = document.createElement('div');
-        textContainer.className = 'flex flex-col text-sm text-blue-100';
-
-        const labelLine = document.createElement('div');
-        labelLine.className = 'flex items-center gap-2';
+        textContainer.className = 'flex items-center gap-2 text-sm text-blue-100';
 
         const labelSpan = document.createElement('span');
         labelSpan.className = 'text-cyan-100 font-semibold';
         labelSpan.textContent = item.label;
 
-        labelLine.appendChild(labelSpan);
+        textContainer.appendChild(labelSpan);
         
         // Only add category badge if category is defined
         if (item.category) {
             const badge = document.createElement('span');
             badge.className = `preference-badge ${item.category === 'optional' ? 'preference-badge-optional' : 'preference-badge-recommended'}`;
             badge.textContent = item.category === 'optional' ? 'Optional' : 'Recommended';
-            labelLine.appendChild(badge);
+            textContainer.appendChild(badge);
         }
-
-        const description = document.createElement('span');
-        description.className = 'text-xs opacity-80';
-        description.textContent = item.description;
-
-        textContainer.appendChild(labelLine);
-        textContainer.appendChild(description);
 
         itemWrapper.appendChild(checkbox);
         itemWrapper.appendChild(textContainer);
@@ -332,7 +325,7 @@ function renderTargetAccounts() {
         header.appendChild(controls);
 
         const charactersContainer = document.createElement('div');
-        charactersContainer.className = 'space-y-1';
+        charactersContainer.className = 'space-y-0.5';  /* Reduced spacing between character items */
 
         const characters = [...account.characters].sort((a, b) => {
             const nameA = (a.name || '').toLowerCase();
@@ -373,18 +366,29 @@ function renderTargetAccounts() {
             });
 
             const text = document.createElement('div');
-            text.className = 'flex flex-col text-sm text-gray-100';
+            text.className = 'text-sm text-gray-100';
 
-            const nameLine = document.createElement('span');
-            nameLine.textContent = char.name || `Character ${char.id}`;
-
-            const metaLine = document.createElement('span');
-            metaLine.className = 'text-xs opacity-70';
-            metaLine.textContent = `ID: ${char.id}` + (isSource ? ' • Source character' : '');
+            // Put name and ID on same line
+            const nameLine = document.createElement('div');
+            nameLine.className = 'flex items-center gap-1';
+            
+            const nameSpan = document.createElement('span');
+            nameSpan.textContent = char.name || `Character ${char.id}`;
+            nameLine.appendChild(nameSpan);
+            
+            const idSpan = document.createElement('span');
+            idSpan.className = 'text-xs opacity-70';
+            idSpan.textContent = `(ID: ${char.id})`;
+            nameLine.appendChild(idSpan);
+            
+            if (isSource) {
+                const sourceIndicator = document.createElement('span');
+                sourceIndicator.className = 'text-xs opacity-70 ml-1';
+                sourceIndicator.textContent = '• Source';
+                nameLine.appendChild(sourceIndicator);
+            }
 
             text.appendChild(nameLine);
-            text.appendChild(metaLine);
-
             characterRow.appendChild(checkbox);
             characterRow.appendChild(text);
 
@@ -426,6 +430,31 @@ function handleSelectAllTargets() {
 function handleClearAllTargets() {
     selectedTargets.clear();
     renderTargetAccounts();
+}
+
+function handleSelectAllPrefs() {
+    const checkboxes = preferenceItemsContainer.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+        checkbox.checked = true;
+    });
+}
+
+function handleClearAllPrefs() {
+    const checkboxes = preferenceItemsContainer.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+        checkbox.checked = false;
+    });
+}
+
+function handleDefaultPrefs() {
+    const checkboxes = preferenceItemsContainer.querySelectorAll('input[type="checkbox"]');
+    checkboxes.forEach(checkbox => {
+        // Find the corresponding preference item and set checkbox to its default
+        const prefItem = PREFERENCE_ITEMS.find(item => item.id === checkbox.value);
+        if (prefItem) {
+            checkbox.checked = prefItem.defaultChecked;
+        }
+    });
 }
 
 function getSelectedPreferenceItems() {
@@ -679,6 +708,9 @@ function initialiseEventHandlers() {
 
     selectAllTargetsBtn.addEventListener('click', handleSelectAllTargets);
     clearAllTargetsBtn.addEventListener('click', handleClearAllTargets);
+    selectAllPrefsBtn.addEventListener('click', handleSelectAllPrefs);
+    clearAllPrefsBtn.addEventListener('click', handleClearAllPrefs);
+    defaultPrefsBtn.addEventListener('click', handleDefaultPrefs);
 
     copyBtn.addEventListener('click', () => handleCopyPreferences(false));
     copyWithBackupBtn.addEventListener('click', () => handleCopyPreferences(true));

--- a/static/js/preferences.js
+++ b/static/js/preferences.js
@@ -41,8 +41,8 @@ const PREFERENCE_ITEMS = [
         id: 'containersShortcutBars',
         label: 'Containers/ShortcutBar*.xml',
         description: 'Shortcut bar positions and contents. Copy with caution when professions differ.',
-        defaultChecked: true,
-        category: 'recommended'
+        defaultChecked: false,
+        category: 'optional'
     },
     {
         id: 'dockAreasLayouts',
@@ -55,29 +55,45 @@ const PREFERENCE_ITEMS = [
         id: 'dockAreasMap',
         label: 'DockAreas/PlanetMapViewConfig.xml',
         description: 'Planet map configuration including window placement and zoom state.',
-        defaultChecked: true,
-        category: 'recommended'
+        defaultChecked: true
     },
     {
         id: 'dockAreasRollup',
         label: 'DockAreas/RollupArea.xml',
         description: 'Roll-up window states—what is expanded or collapsed.',
         defaultChecked: true,
-        category: 'recommended'
+        category: 'optional'
     },
     {
         id: 'disabledTips',
         label: 'DisabledTipsMap.xml',
         description: 'Tracks which tutorial tips were dismissed. Optional quality-of-life preference.',
-        defaultChecked: false,
+        defaultChecked: true,
         category: 'optional'
     },
     {
-        id: 'binFiles',
-        label: '*.bin files',
-        description: 'Binary preference data such as icon positions, ignore lists, macros, and references.',
-        defaultChecked: false,
-        category: 'optional'
+        id: 'iconPositionsBin',
+        label: 'IconPositions.bin',
+        description: 'Binary icon placement data (hotbars, HUD icons). Copy if you want identical positioning.',
+        defaultChecked: true
+    },
+    {
+        id: 'ignoreListBin',
+        label: 'IgnoreList.bin',
+        description: 'Ignored players list. Optional and potentially sensitive.',
+        defaultChecked: true
+    },
+    {
+        id: 'referencesBin',
+        label: 'References.bin',
+        description: 'Internal reference cache. Usually safe to copy but optional.',
+        defaultChecked: false
+    },
+    {
+        id: 'textMacroBin',
+        label: 'TextMacro.bin',
+        description: 'Chat macros and quick text bindings.',
+        defaultChecked: false
     }
 ];
 
@@ -218,12 +234,15 @@ function renderPreferenceItems() {
         labelSpan.className = 'text-cyan-100 font-semibold';
         labelSpan.textContent = item.label;
 
-        const badge = document.createElement('span');
-        badge.className = `preference-badge ${item.category === 'optional' ? 'preference-badge-optional' : 'preference-badge-recommended'}`;
-        badge.textContent = item.category === 'optional' ? 'Optional' : 'Recommended';
-
         labelLine.appendChild(labelSpan);
-        labelLine.appendChild(badge);
+        
+        // Only add category badge if category is defined
+        if (item.category) {
+            const badge = document.createElement('span');
+            badge.className = `preference-badge ${item.category === 'optional' ? 'preference-badge-optional' : 'preference-badge-recommended'}`;
+            badge.textContent = item.category === 'optional' ? 'Optional' : 'Recommended';
+            labelLine.appendChild(badge);
+        }
 
         const description = document.createElement('span');
         description.className = 'text-xs opacity-80';

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -8,7 +8,8 @@ let appSettings = {
     gameFolder: "", // Default empty, user will input
     dllFolder: "",  // Default empty, user will input
     accounts: [],   // Array to store account objects
-    autoCycle: false // Whether to auto-cycle characters
+    autoCycle: false, // Whether to auto-cycle characters
+    prefsBasePath: ""
 };
 
 // --- DOM Elements ---
@@ -59,6 +60,7 @@ function loadSettingsFromLocalStorage() {
             appSettings.gameFolder = parsedSettings.gameFolder || "";
             appSettings.dllFolder = parsedSettings.dllFolder || "";
             appSettings.autoCycle = parsedSettings.autoCycle || false;
+            appSettings.prefsBasePath = parsedSettings.prefsBasePath || "";
             if (Array.isArray(parsedSettings.accounts)) {
                 // Data migration: ensure character IDs are numbers for backwards compatibility
                 parsedSettings.accounts.forEach(account => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,6 +12,11 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 </head>
 <body class="font-inter min-h-screen flex flex-col items-center p-3">
+    <div class="w-full max-w-5xl mb-2">
+        <div class="flex justify-end text-xs text-cyan-300">
+            <a href="{{ url_for('preferences') }}" class="hover:underline tracking-wide">Character Preference Copier</a>
+        </div>
+    </div>
     <div class="container mx-auto p-1 rounded-lg shadow-xl max-w-5xl w-full">
 
         <!-- Configuration Paths Section -->

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AO Launcher – Preference Copier</title>
+    <link rel="icon" type="image/x-icon" href="/static/favicon.ico">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="/static/css/style.css">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+</head>
+<body class="font-inter min-h-screen flex flex-col items-center p-3">
+    <div class="w-full max-w-5xl mb-2">
+        <div class="flex justify-between text-xs text-cyan-300">
+            <a href="{{ url_for('index') }}" class="hover:underline tracking-wide">&#8592; Back to Launcher</a>
+            <span class="opacity-75">Preference Copier</span>
+        </div>
+    </div>
+    <div class="container mx-auto p-4 rounded-lg shadow-xl max-w-5xl w-full space-y-4">
+        <header class="space-y-1">
+            <h1 class="text-2xl font-semibold text-cyan-300">Character Preference Copier</h1>
+            <p class="text-sm text-blue-100">Quickly copy recommended Anarchy Online preference files between characters while keeping backups when needed.</p>
+        </header>
+
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-2">
+            <h2 class="text-lg font-semibold text-cyan-200">Preference Base Folder</h2>
+            <p class="text-xs text-blue-100">Set the path to your <span class="font-mono">Prefs</span> directory (e.g. <span class="font-mono">C:\Users\&lt;you&gt;\AppData\Local\Funcom\Anarchy Online\&lt;profile&gt;\Anarchy Online\Prefs</span>).</p>
+            <div class="flex flex-col md:flex-row gap-2">
+                <input type="text" id="prefsBasePath" class="flex-1 shadow appearance-none border rounded-lg py-2 px-2 leading-tight focus:outline-none focus:shadow-outline" placeholder="C:\\Users\\<you>\\AppData\\Local\\Funcom\\Anarchy Online\\...\\Prefs">
+                <button id="savePrefsBasePathBtn" class="px-4 py-2 rounded-lg uppercase">Save Path</button>
+            </div>
+        </section>
+
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-3">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                <div class="flex-1">
+                    <label for="sourceCharacter" class="block text-lg font-semibold text-cyan-200">Copy from Character</label>
+                    <select id="sourceCharacter" class="w-full mt-1 bg-transparent border border-cyan-900/60 rounded-lg px-2 py-2 focus:outline-none focus:ring focus:ring-cyan-500">
+                        <option value="">Select a character</option>
+                    </select>
+                </div>
+                <div class="flex flex-col text-xs text-blue-100 space-y-1">
+                    <span class="font-semibold text-cyan-200">What gets copied?</span>
+                    <span>Hover over an item below to learn what data it contains.</span>
+                </div>
+            </div>
+
+            <div>
+                <h3 class="text-md font-semibold text-cyan-200 mb-1">Preference Items</h3>
+                <div id="preferenceItems" class="grid grid-cols-1 md:grid-cols-2 gap-2"></div>
+            </div>
+        </section>
+
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-3">
+            <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div>
+                    <h2 class="text-lg font-semibold text-cyan-200">Select Target Characters</h2>
+                    <p class="text-xs text-blue-100">Choose any characters that should receive the copied preferences.</p>
+                </div>
+                <div class="flex gap-2 text-xs">
+                    <button id="selectAllTargets" class="px-3 py-1 rounded-md uppercase">Select All</button>
+                    <button id="clearAllTargets" class="px-3 py-1 rounded-md uppercase">Select None</button>
+                </div>
+            </div>
+            <div id="targetAccountsContainer" class="grid grid-cols-1 md:grid-cols-2 gap-2"></div>
+        </section>
+
+        <section class="flex flex-col sm:flex-row gap-3 justify-end">
+            <button id="copyWithBackupBtn" class="px-4 py-3 rounded-lg uppercase">Copy with Backup</button>
+            <button id="copyBtn" class="px-4 py-3 rounded-lg uppercase">Copy Preferences</button>
+        </section>
+
+        <div id="prefsMessageBox" class="mt-2 p-3 rounded-lg text-center hidden"></div>
+    </div>
+
+    <script src="/static/js/preferences.js"></script>
+</body>
+</html>

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -65,9 +65,12 @@
             <div id="targetAccountsContainer" class="grid grid-cols-1 md:grid-cols-2 gap-2"></div>
         </section>
 
-        <section class="flex flex-col sm:flex-row gap-3 justify-end">
-            <button id="copyWithBackupBtn" class="px-4 py-3 rounded-lg uppercase">Copy with Backup</button>
-            <button id="copyBtn" class="px-4 py-3 rounded-lg uppercase">Copy Preferences</button>
+        <section class="flex flex-col sm:flex-row gap-3 justify-between">
+            <button id="deleteShortcutbarsBtn" class="px-4 py-3 rounded-lg uppercase bg-red-700 hover:bg-red-600 text-white">Delete Shortcutbars</button>
+            <div class="flex flex-col sm:flex-row gap-3">
+                <button id="copyWithBackupBtn" class="px-4 py-3 rounded-lg uppercase">Copy with Backup</button>
+                <button id="copyBtn" class="px-4 py-3 rounded-lg uppercase">Copy Preferences</button>
+            </div>
         </section>
 
         <div id="prefsMessageBox" class="mt-2 p-3 rounded-lg text-center hidden"></div>

--- a/templates/preferences.html
+++ b/templates/preferences.html
@@ -13,49 +13,46 @@
     <div class="w-full max-w-5xl mb-2">
         <div class="flex justify-between text-xs text-cyan-300">
             <a href="{{ url_for('index') }}" class="hover:underline tracking-wide">&#8592; Back to Launcher</a>
-            <span class="opacity-75">Preference Copier</span>
         </div>
     </div>
     <div class="container mx-auto p-4 rounded-lg shadow-xl max-w-5xl w-full space-y-4">
-        <header class="space-y-1">
-            <h1 class="text-2xl font-semibold text-cyan-300">Character Preference Copier</h1>
-            <p class="text-sm text-blue-100">Quickly copy recommended Anarchy Online preference files between characters while keeping backups when needed.</p>
-        </header>
-
         <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-2">
             <h2 class="text-lg font-semibold text-cyan-200">Preference Base Folder</h2>
-            <p class="text-xs text-blue-100">Set the path to your <span class="font-mono">Prefs</span> directory (e.g. <span class="font-mono">C:\Users\&lt;you&gt;\AppData\Local\Funcom\Anarchy Online\&lt;profile&gt;\Anarchy Online\Prefs</span>).</p>
             <div class="flex flex-col md:flex-row gap-2">
                 <input type="text" id="prefsBasePath" class="flex-1 shadow appearance-none border rounded-lg py-2 px-2 leading-tight focus:outline-none focus:shadow-outline" placeholder="C:\\Users\\<you>\\AppData\\Local\\Funcom\\Anarchy Online\\...\\Prefs">
                 <button id="savePrefsBasePathBtn" class="px-4 py-2 rounded-lg uppercase">Save Path</button>
             </div>
         </section>
 
-        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-3">
-            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-2">
+            <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
                 <div class="flex-1">
                     <label for="sourceCharacter" class="block text-lg font-semibold text-cyan-200">Copy from Character</label>
                     <select id="sourceCharacter" class="w-full mt-1 bg-transparent border border-cyan-900/60 rounded-lg px-2 py-2 focus:outline-none focus:ring focus:ring-cyan-500">
                         <option value="">Select a character</option>
                     </select>
                 </div>
-                <div class="flex flex-col text-xs text-blue-100 space-y-1">
-                    <span class="font-semibold text-cyan-200">What gets copied?</span>
-                    <span>Hover over an item below to learn what data it contains.</span>
-                </div>
             </div>
+        </section>
 
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-2">
             <div>
-                <h3 class="text-md font-semibold text-cyan-200 mb-1">Preference Items</h3>
+                <div class="flex justify-between items-center mb-1">
+                    <h2 class="text-lg font-semibold text-cyan-200">Prefs to Copy</h3>
+                    <div class="flex gap-2 text-xs">
+                        <button id="selectAllPrefs" class="px-3 py-1 rounded-md uppercase">Select All</button>
+                        <button id="clearAllPrefs" class="px-3 py-1 rounded-md uppercase">Select None</button>
+                        <button id="defaultPrefs" class="px-3 py-1 rounded-md uppercase">Default</button>
+                    </div>
+                </div>
                 <div id="preferenceItems" class="grid grid-cols-1 md:grid-cols-2 gap-2"></div>
             </div>
         </section>
 
-        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-3">
+        <section class="bg-slate-900/40 border border-cyan-900/40 rounded-lg p-3 space-y-2">
             <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
                 <div>
                     <h2 class="text-lg font-semibold text-cyan-200">Select Target Characters</h2>
-                    <p class="text-xs text-blue-100">Choose any characters that should receive the copied preferences.</p>
                 </div>
                 <div class="flex gap-2 text-xs">
                     <button id="selectAllTargets" class="px-3 py-1 rounded-md uppercase">Select All</button>
@@ -68,8 +65,8 @@
         <section class="flex flex-col sm:flex-row gap-3 justify-between">
             <button id="deleteShortcutbarsBtn" class="px-4 py-3 rounded-lg uppercase bg-red-700 hover:bg-red-600 text-white">Delete Shortcutbars</button>
             <div class="flex flex-col sm:flex-row gap-3">
-                <button id="copyWithBackupBtn" class="px-4 py-3 rounded-lg uppercase">Copy with Backup</button>
                 <button id="copyBtn" class="px-4 py-3 rounded-lg uppercase">Copy Preferences</button>
+                <button id="copyWithBackupBtn" class="px-4 py-3 rounded-lg uppercase">Copy with Backup</button>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a dedicated character preference copier page with dropdown source selection, per-file toggles, and per-account target controls
- implement backend endpoint to copy recommended AO preference files with optional backups based on PREFS overview guidance
- update shared settings to store the Prefs base path and expose navigation between launcher and preference copier

## Testing
- python -m compileall app.py static/js/preferences.js static/js/script.js

------
https://chatgpt.com/codex/tasks/task_e_68cf11803d488324a560feab5233c737